### PR TITLE
Specify Ruby version in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,9 @@
 source 'https://rubygems.org'
+ruby '2.2.2'
 
 gem 'rake'
 gem 'dashing'
-gem 'json', '~> 1.7.7'
+gem 'json'
 gem 'dotenv'
 gem 'octokit'
 gem 'i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
     ffi (1.9.6)
     hike (1.2.3)
     i18n (0.7.0)
-    json (1.7.7)
+    json (1.8.2)
     minitest (5.5.1)
     multi_json (1.10.1)
     multipart-post (2.0.0)
@@ -114,7 +114,7 @@ DEPENDENCIES
   faraday (~> 0.9)
   faraday-http-cache
   i18n
-  json (~> 1.7.7)
+  json
   octokit
   rake
   rspec


### PR DESCRIPTION
Without a Ruby version specified, CloudFoundry will default to 2.0.0. We want the latest and greatest.
