### PR TITLE
Add initial customization for 18F repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .env
 !.env.sample
 tmp
+history.yml

--- a/assets/stylesheets/custom.scss
+++ b/assets/stylesheets/custom.scss
@@ -59,7 +59,7 @@ h2 .value-add {
 		}
 
 		&.widget-graph .y_ticks {
-			fill: rgba(255,255,255,0.5);	
+			fill: rgba(255,255,255,0.5);
 		}
 
 	}
@@ -73,7 +73,7 @@ h2 .value-add {
 			position: inherit;
 			top: auto;
 			bottom: auto;
-		}	
+		}
 	}
 
 	&.widget-table {
@@ -85,7 +85,7 @@ h2 .value-add {
 				color: $red;
 			}
 		}
-		
+
 	}
 
 	&.leaderboard {
@@ -241,8 +241,8 @@ h2 .value-add {
 			li {
 				font-size: 11px;
 				border-radius: 3px;
-				margin: 0 5px 0 0;	
-				padding: 0;	
+				margin: 0 5px 0 0;
+				padding: 0;
 			}
 		}
 	}
@@ -258,7 +258,7 @@ h2 .value-add {
 	}
 }
 
-h1, footer {
+h1 {
 	margin: 5px; // simulate widget spacing
 	padding: 5px;
 	text-align: center;
@@ -267,7 +267,9 @@ h1, footer {
 footer {
 	color: rgba(255, 255, 255, 0.5);
 	font-size: 12px;
+	margin: 5px;
 	padding: 15px;
+	text-align: left;
 
 	a {
 		color: rgba(255, 255, 255, 0.7);

--- a/dashboards/default.erb
+++ b/dashboards/default.erb
@@ -1,65 +1,46 @@
 <% content_for(:title) { "Github Open Source Dashboard" } %>
 <div class="gridster highcontrast">
-  <h1 class="header">SilverStripe Contributions Dashboard</h1>
+  <h1 class="header">18F Projects Dashboard</h1>
   <ul>
-    <li data-row="1" data-col="1" data-sizex="2" data-sizey="4">
-      <div 
-        data-id="leaderboard" 
-        data-view="Leaderboard" 
-        data-unordered="true">
-      </div>
-    </li>
-    <li data-row="1" data-col="3" data-sizex="2" data-sizey="1">
-      <div 
-        data-id="pull_requests" 
-        data-view="SeriesGraph" 
+    <li data-row="1" data-col="1" data-sizex="4" data-sizey="1">
+      <div
+        data-id="pull_requests"
+        data-view="SeriesGraph"
         data-renderer="bar"
-        data-colors="#fff #888" 
-        data-title="Pulls opened this month" 
-        data-subtitle="Projected monthly trend compared to last month" 
+        data-colors="#fff #888"
+        data-title="Pulls opened this month"
+        data-subtitle="Projected monthly trend compared to last month"
         data-padding-top="0.35"
         class="widget-graph widget-graph-large-change-rate">
       </div>
     </li>
-    <li data-row="2" data-col="3" data-sizex="2" data-sizey="1">
-      <div 
-        data-id="issues_opened" 
-        data-view="SeriesGraph" 
+    <li data-row="2" data-col="1" data-sizex="4" data-sizey="1">
+      <div
+        data-id="issues_opened"
+        data-view="SeriesGraph"
         data-renderer="bar"
-        data-colors="#fff #888" 
-        data-title="Issues opened this month" 
-        data-subtitle="Projected monthly trend compared to last month" 
+        data-colors="#fff #888"
+        data-title="Issues opened this month"
+        data-subtitle="Projected monthly trend compared to last month"
         data-padding-top="0.35"
         class="widget-graph widget-graph-large-change-rate">
       </div>
     </li>
-    <li data-row="3" data-col="3" data-sizex="2" data-sizey="1">
-      <div 
-        data-id="issues_closed" 
-        data-view="SeriesGraph" 
+    <li data-row="3" data-col="1" data-sizex="4" data-sizey="1">
+      <div
+        data-id="issues_closed"
+        data-view="SeriesGraph"
         data-renderer="bar"
-        data-colors="#fff #888" 
-        data-title="Issues closed this month" 
-        data-subtitle="Projected monthly trend compared to last month" 
-        data-padding-top="0.35"
-        class="widget-graph widget-graph-large-change-rate">
-      </div>
-    </li>
-     <li data-row="4" data-col="3" data-sizex="2" data-sizey="1">
-      <div 
-        data-id="forum_unanswered" 
-        data-view="SeriesGraph" 
-        data-renderer="bar"
-        data-colors="#fff #888" 
-        data-title="Unanswered forum posts" 
-        data-subtitle="Projected monthly trend compared to last month" 
+        data-colors="#fff #888"
+        data-title="Issues closed this month"
+        data-subtitle="Projected monthly trend compared to last month"
         data-padding-top="0.35"
         class="widget-graph widget-graph-large-change-rate">
       </div>
     </li>
     <li data-row="1" data-col="5" data-sizex="3" data-sizey="4">
-      <div 
-        data-id="travis" 
+      <div
+        data-id="travis"
         data-view="NestedList"
         data-title="Travis Build Status">
       </div>

--- a/widgets/meta/meta.html
+++ b/widgets/meta/meta.html
@@ -1,11 +1,9 @@
 <h1 class="title" data-bind="title" data-showif="title"></h1>
 
 <p>
-	Powered by <a href="https://github.com/chillu/github-dashing">Github-Dashing</a> 
+	Powered by <a href="https://github.com/18F/github-dashing">Github-Dashing</a>
 	and <a href="https://github.com/Shopify/dashing">Dashing</a>.
-  Data provided by <a href="http://developer.github.com/v3/">github.com</a>.
-  Inspecting <span data-bind="repo_count" data-bind-title="repo_titles"></span> repositories, starting from <span data-bind="since"></span>. 
-  See <a href="http://github-dashing.herokuapp.com">http://github-dashing.herokuapp.com</a>.
+  Inspecting <span data-bind="repo_count" data-bind-title="repo_titles"></span> GitHub repositories, starting from <span data-bind="since"></span>.
 </p>
 
 <h3 data-bind="text | raw"></h3>


### PR DESCRIPTION
- Change the header from "SilverStripe Contributions" to "18F Projects"
- Remove the Leaderboard widget
- Make the GitHub stats widgets wider
- Update the footer text and align it on the left instead of center because it runs into the Travis column
- Add a mysterious history.yml file to .gitignore. I can't find any reference to it in the code, so I don't think it's needed.

You can see what it looks like here: http://project-dashboard.cf.18f.us/default
