### PR TITLE
Ignore nonexistent builds from Travis widget

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,5 +3,5 @@ REPOS=
 SINCE=12.months.ago.beginning_of_month
 GITHUB_LOGIN=
 GITHUB_OAUTH_TOKEN=
-TRAVIS_BRANCH_BLACKLIST={"silverstripe-labs/silverstripe-newsletter":["0.3","0.4"]}
+TRAVIS_IGNORED_REPOS=18F/save-ferris
 SENTRY_DSN=

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,3 +1,5 @@
 ruby:
   config_file: .rubocop.yml
+scss:
+  config_file: .scss-lint.yml
 fail_on_violations: true

--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -1,0 +1,4 @@
+linters:
+  SelectorFormat:
+    exclude:
+      - '/assets/stylesheets/custom.scss'

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -35,22 +35,22 @@ $text-danger-color: #fff;
 // ----------------------------------------------------------------------------
 // Base styles
 // ----------------------------------------------------------------------------
-html { 
-  font-size: 100%; 
-  -webkit-text-size-adjust: 100%; 
-  -ms-text-size-adjust: 100%; 
+html {
+  font-size: 100%;
+  -webkit-text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
 }
 
-body { 
-  margin: 0; 
+body {
+  margin: 0;
   background-color: $background-color;
   font-size: 20px;
   color: $text-color;
   font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
 }
 
-b, strong { 
-  font-weight: bold; 
+b, strong {
+  font-weight: bold;
 }
 
 a {
@@ -58,18 +58,18 @@ a {
   color: inherit;
 }
 
-img { 
-  border: 0; 
-  -ms-interpolation-mode: bicubic; 
-  vertical-align: middle; 
+img {
+  border: 0;
+  -ms-interpolation-mode: bicubic;
+  vertical-align: middle;
 }
 
-img, object { 
-  max-width: 100%; 
+img, object {
+  max-width: 100%;
 }
 
-iframe { 
-  max-width: 100%; 
+iframe {
+  max-width: 100%;
 }
 
 table {
@@ -82,16 +82,16 @@ td {
   vertical-align: middle;
 }
 
-ul, ol { 
-  padding: 0; 
-  margin: 0; 
+ul, ol {
+  padding: 0;
+  margin: 0;
 }
 
-h1, h2, h3, h4, h5, p { 
+h1, h2, h3, h4, h5, p {
   padding: 0;
-  margin: 0; 
+  margin: 0;
 }
-h1 { 
+h1 {
   margin-bottom: 12px;
   text-align: center;
   font-size: 30px;
@@ -152,7 +152,7 @@ h3 {
   background-color: $background-warning-color-1;
   @include animation(status-warning-background, 2s, ease, infinite);
 
-  .icon-warning-sign { 
+  .icon-warning-sign {
     display: inline-block;
   }
 
@@ -166,7 +166,7 @@ h3 {
   background-color: $background-danger-color-1;
   @include animation(status-danger-background, 2s, ease, infinite);
 
-  .icon-warning-sign { 
+  .icon-warning-sign {
     display: inline-block;
   }
 
@@ -187,7 +187,7 @@ h3 {
   font-size: 15px;
   position: absolute;
   bottom: 12px;
-  left: 0;
+  left: 300px;
   right: 0;
 }
 

--- a/assets/stylesheets/application.scss
+++ b/assets/stylesheets/application.scss
@@ -37,19 +37,20 @@ $text-danger-color: #fff;
 // ----------------------------------------------------------------------------
 html {
   font-size: 100%;
-  -webkit-text-size-adjust: 100%;
   -ms-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
 }
 
 body {
-  margin: 0;
   background-color: $background-color;
-  font-size: 20px;
   color: $text-color;
   font-family: 'Open Sans', "Helvetica Neue", Helvetica, Arial, sans-serif;
+  font-size: 20px;
+  margin: 0;
 }
 
-b, strong {
+b,
+strong {
   font-weight: bold;
 }
 
@@ -64,7 +65,8 @@ img {
   vertical-align: middle;
 }
 
-img, object {
+img,
+object {
   max-width: 100%;
 }
 
@@ -82,15 +84,22 @@ td {
   vertical-align: middle;
 }
 
-ul, ol {
+ul,
+ol {
+  margin: 0;
+  padding: 0;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+p {
   padding: 0;
   margin: 0;
 }
 
-h1, h2, h3, h4, h5, p {
-  padding: 0;
-  margin: 0;
-}
 h1 {
   margin-bottom: 12px;
   text-align: center;

--- a/assets/stylesheets/custom.scss
+++ b/assets/stylesheets/custom.scss
@@ -93,7 +93,7 @@ h2 .value-add {
 		color: #777;
 	}
 
-	&.travis {
+	&.travis, &.testable {
 		background-color: #aaa;
 		font-size: 14px;
 

--- a/assets/stylesheets/custom.scss
+++ b/assets/stylesheets/custom.scss
@@ -102,10 +102,10 @@ h2 .value-add {
     background-color: transparent;
     color: $grey;
   }
-  // scss-lint:enable SelectorFormat
 
   &.travis,
-  &.testable {
+  &.testable_without_ci {
+  // scss-lint:enable SelectorFormat
     font-size: 14px;
 
     ul {

--- a/assets/stylesheets/custom.scss
+++ b/assets/stylesheets/custom.scss
@@ -1,237 +1,205 @@
 $green: #76ab13;
 $red: #ae442e;
 $orange: orange;
+$background-color: #222;
+$widget-background-color: #333;
+$grey: #777;
+$text-color: #fff;
+$black: #000;
 
 .good {
-	color: rgba(0, 255, 0, 0.4);
+  color: rgba(0, 255, 0, 0.4);
 }
 
 .bad {
-	color: rgba(255, 0, 0, 0.4);
+  color: rgba(255, 0, 0, 0.4);
 }
 
 h1 {
-	font-size: 22px;
+  font-size: 22px;
 }
 
 h1.header {
-	color: rgba(255,255,255,0.5);
-	font-weight: bold;
-	font-size: 30px;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 30px;
+  font-weight: bold;
 }
 
 h2 .value-add {
-	font-size: 0.4em;
-	vertical-align: middle;
+  font-size: 0.4em;
+  vertical-align: middle;
 }
 
 .trend-up {
-	color: $green;
+  color: $green;
 }
 
 .trend-down {
-	color: $red;
+  color: $red;
 }
 
 .more-info {
-	font-size: 12px;
-	opacity: 0.5;
+  font-size: 12px;
+  opacity: 0.5;
 }
 
 .highcontrast {
 
-	background-color: #222;
+  background-color: $background-color;
 
-	.widget {
-		color: white;
-		background-color: #333 !important;
-		padding: 0;
+  .widget {
+    background-color: $widget-background-color;
+    color: $text-color;
+    padding: 0;
 
-		.updated-at {
-			color: rgba(255,255,255,0.5);
-		}
+    // scss-lint:disable SelectorDepth, SelectorFormat
+    .updated-at {
+      color: rgba(255, 255, 255, 0.5);
+    }
 
-		.x_tick .title {
-			color: rgba(255,255,255,0.5);
-			// Avoid overlap with cols, a bit hacky
-			padding-bottom: 15px;
-			padding-left: 10px;
-		}
+    .x_tick .title {
+      color: rgba(255, 255, 255, 0.5);
+      // Avoid overlap with cols, a bit hacky
+      padding-bottom: 15px;
+      padding-left: 10px;
+    }
 
-		&.widget-graph .y_ticks {
-			fill: rgba(255,255,255,0.5);
-		}
+    &.widget-graph .y_ticks {
+      fill: rgba(255, 255, 255, 0.5);
+    }
+    // scss-lint:enable SelectorDepth, SelectorFormat
 
-	}
+  }
 }
 
 .widget {
-	vertical-align: top;
+  vertical-align: top;
 
-	&.widget-graph, &.widget-series {
-		.more-info {
-			position: inherit;
-			top: auto;
-			bottom: auto;
-		}
-	}
+  &.widget-graph,
+  &.widget-series {
+    .more-info {
+      bottom: auto;
+      position: inherit;
+      top: auto;
+    }
+  }
 
-	&.widget-table {
-		td {
-			&.trend-up {
-				color: $green;
-			}
-			&.trend-down {
-				color: $red;
-			}
-		}
+  &.widget-table {
+    td {
+      &.trend-up {
+        color: $green;
+      }
 
-	}
+      &.trend-down {
+        color: $red;
+      }
+    }
 
-	&.meta_stats {
-		background-color: transparent;
-		color: #777;
-	}
+  }
 
-	&.travis, &.testable {
-		background-color: #aaa;
-		font-size: 14px;
+  // scss-lint:disable SelectorFormat
+  &.meta_stats {
+    background-color: transparent;
+    color: $grey;
+  }
+  // scss-lint:enable SelectorFormat
 
-		ul {
-			margin: 0;
-		}
+  &.travis,
+  &.testable {
+    font-size: 14px;
 
-		li {
-			float: left;
-			margin: 0 5px 5px 0;
-			padding: 3px;
-			border-radius: 3px;
+    ul {
+      margin: 0;
+    }
 
-			* {
-				vertical-align: middle;
-			}
+    li {
+      border-radius: 3px;
+      float: left;
+      margin: 0 5px 5px 0;
+      padding: 3px;
 
-			&.good {
-				background-color: darken($green, 10%);
-			}
+      // scss-lint:disable SelectorDepth
+      * {
+        vertical-align: middle;
+      }
+      // scss-lint:enable SelectorDepth
 
-			&.bad {
-				background-color: $red;
+      &.good {
+        background-color: darken($green, 10%);
+      }
 
-				// Show broken builds larger,
-				// with labels on a separate line.
-				.label {
-					font-size: 24px;
-					display: block;
-				}
+      &.bad {
+        background-color: $red;
 
-				ul {
-					display: block;
+        // Show broken builds larger,
+        // with labels on a separate line.
+        // scss-lint:disable SelectorDepth, NestingDepth
+        .label {
+          display: block;
+          font-size: 24px;
+        }
 
-					.label {
-						font-size: 14px;
-					}
-				}
-			}
+        ul {
+          display: block;
 
-			&.none {
-				background-color: #555;
-			}
+          .label {
+            font-size: 14px;
+          }
+        }
+        // scss-lint:enable SelectorDepth, NestingDepth
+      }
 
-			&.rating {
-				border-radius: 5px;
-				background: darken($orange, 10%);
-				padding: 0px 4px;
-				color: black;
-				font-size: 10px;
+      // scss-lint:disable SelectorDepth
+      a {
+        padding: 2px 4px;
+      }
 
-				&.rating-0 {
-					background-color: $red;
-				}
+      a,
+      ul,
+      li {
+        display: inline-block;
+      }
 
-				&.rating-1 {
-					background-color: $red;
-				}
+      li {
+        border-radius: 3px;
+        font-size: 11px;
+        margin: 0 5px 0 0;
+        padding: 0;
+      }
+      // scss-lint:enable SelectorDepth
+    }
+  }
 
-				&.rating-2 {
-					background-color: $red;
-				}
+  // scss-lint:disable SelectorFormat
+  &.issues_stacked,
+  &.issues_opened,
+  &.forum_unanswered {
+  // scss-lint:enable SelectorFormat
+    // Reverse trends, up is bad
+    .trend-up {
+      color: $red;
+    }
 
-				&.rating-3 {
-					background-color: darken($orange, 10%);
-				}
-
-				&.rating-4 {
-					background-color: darken($orange, 10%);
-				}
-
-				&.rating-5 {
-					background-color: darken($orange, 10%);
-				}
-
-				&.rating-6 {
-					background-color: darken($orange, 10%);
-				}
-
-				&.rating-7 {
-					background-color: darken($green, 10%);
-				}
-
-				&.rating-8 {
-					background-color: darken($green, 10%);
-				}
-
-				&.rating-9 {
-					background-color: darken($green, 10%);
-				}
-
-				&.rating-10 {
-					background-color: darken($green, 10%);
-				}
-			}
-
-			a {
-				padding: 2px 4px;
-			}
-
-			a, ul, li {
-				display: inline-block;
-			}
-
-			li {
-				font-size: 11px;
-				border-radius: 3px;
-				margin: 0 5px 0 0;
-				padding: 0;
-			}
-		}
-	}
-
-	&.issues_stacked, &.issues_opened, &.forum_unanswered {
-		// Reverse trends, up is bad
-		.trend-up {
-			color: $red;
-		}
-		.trend-down {
-			color: $green;
-		}
-	}
+    .trend-down {
+      color: $green;
+    }
+  }
 }
 
 h1 {
-	margin: 5px; // simulate widget spacing
-	padding: 5px;
-	text-align: center;
+  margin: 5px; // simulate widget spacing
+  padding: 5px;
+  text-align: center;
 }
 
 footer {
-	color: rgba(255, 255, 255, 0.5);
-	font-size: 12px;
-	margin: 5px;
-	padding: 15px;
-	text-align: left;
+  color: rgba(255, 255, 255, 0.5);
+  font-size: 12px;
+  margin: 5px;
+  padding: 15px;
+  text-align: left;
 
-	a {
-		color: rgba(255, 255, 255, 0.7);
-	}
+  a {
+    color: rgba(255, 255, 255, 0.7);
+  }
 }

--- a/dashboards/default.erb
+++ b/dashboards/default.erb
@@ -45,6 +45,13 @@
         data-title="Travis Build Status">
       </div>
     </li>
+    <li data-row="4" data-col="1" data-sizex="3" data-sizey="1">
+      <div
+        data-id="testable"
+        data-view="NestedList"
+        data-title="Testable without CI">
+      </div>
+    </li>
   </ul>
   <footer data-id="meta_stats" data-view="Meta"></footer>
 </div>

--- a/dashboards/default.erb
+++ b/dashboards/default.erb
@@ -47,7 +47,7 @@
     </li>
     <li data-row="4" data-col="1" data-sizex="3" data-sizey="1">
       <div
-        data-id="testable"
+        data-id="testable_without_ci"
         data-view="NestedList"
         data-title="Testable without CI">
       </div>

--- a/jobs/testable.rb
+++ b/jobs/testable.rb
@@ -1,0 +1,27 @@
+require 'dashing'
+require File.expand_path('../../lib/travis_backend', __FILE__)
+
+SCHEDULER.every '1d', first_in: '1s' do |_job|
+  travis_backend = TravisBackend.new
+  github_backend = GithubBackend.new
+
+  testable_repos = github_backend.testable_repos
+
+  travis_repos = testable_repos.map { |repo| travis_backend.get_repo(repo) }
+  repos_without_builds = travis_repos.select { |repo| repo['last_build_id'].nil? }
+  ignored_repos = ENV['TRAVIS_IGNORED_REPOS'].split(',').compact
+
+  items = repos_without_builds.map do |repo|
+    {
+      'class' => 'bad',
+      'label' => repo['slug'],
+      'url' => "https://github.com/#{repo['slug']}"
+    }
+  end
+
+  items.delete_if { |item| ignored_repos.include?(item['label']) }
+
+  items.sort_by! { |item| [1, item['label']] }
+
+  send_event('testable', unordered: true, items: items)
+end

--- a/jobs/testable_without_ci.rb
+++ b/jobs/testable_without_ci.rb
@@ -1,6 +1,12 @@
 require 'dashing'
 require File.expand_path('../../lib/travis_backend', __FILE__)
 
+# This job uses the 18F Team API to fetch all repos whose `testable`
+# key is set to `true` in their .about.yml. Then, the Travis API is
+# used to get each repo in that list, and if the repo doesn't have a
+# build running on Travis, it gets included in the widget on the dashboard.
+# The goal is to display repos that should have tests running on some CI
+# server, but don't.
 SCHEDULER.every '1d', first_in: '1s' do |_job|
   travis_backend = TravisBackend.new
   github_backend = GithubBackend.new
@@ -23,5 +29,5 @@ SCHEDULER.every '1d', first_in: '1s' do |_job|
 
   items.sort_by! { |item| [1, item['label']] }
 
-  send_event('testable', unordered: true, items: items)
+  send_event('testable_without_ci', unordered: true, items: items)
 end

--- a/jobs/travis.rb
+++ b/jobs/travis.rb
@@ -1,107 +1,44 @@
-require 'json'
-require 'time'
 require 'dashing'
-require 'net/https'
-require 'cgi'
 require File.expand_path('../../lib/travis_backend', __FILE__)
 
-$lastTravisItems = []
+def class_from(build_status)
+  return 'bad' if build_status.nil? || build_status == 1
 
-SCHEDULER.every '2m', :first_in => '1s' do |job|
-	travis_backend = TravisBackend.new
-	repo_slugs = []
-	builds = []
+  'good'
+end
 
-	# Only look at release branches (x.y) and master, not at tags (x.y.z)
-	branch_whitelist = /^(\d+\.\d+$|master)/
-	branch_blacklist_by_repo = {}
-	branch_blacklist_by_repo = JSON.parse(ENV['TRAVIS_BRANCH_BLACKLIST']) if ENV['TRAVIS_BRANCH_BLACKLIST']
+SCHEDULER.every '2m', first_in: '1s' do |_job|
+  travis_backend = TravisBackend.new
+  enabled_repos = []
+  ignored_repos = ENV['TRAVIS_IGNORED_REPOS'].split(',').compact
 
-	# TODO Move to configuration
-	repo_slug_replacements = [/(silverstripe-australia\/|silverstripe-labs\/|silverstripe\/|silverstripe-)/,'']
+  if ENV['ORGS']
+    ENV['ORGS'].split(',').each do |org|
+      enabled_repos = travis_backend.get_enabled_repos_by_org(org)
+    end
+  end
 
-	if ENV['ORGS']
-		ENV['ORGS'].split(',').each do |org|
-			repo_slugs = repo_slugs.concat(travis_backend.get_repos_by_org(org).collect{|repo|repo['slug']})
-		end
-	end
+  items = enabled_repos.map do |repo|
+    {
+      'class' => class_from(repo['last_build_status']),
+      'label' => repo['slug'],
+      'title' => repo['last_build_finished_at'],
+      'url' => "https://travis-ci.org/#{repo['slug']}/builds/#{repo['last_build_id']}"
+    }
+  end
 
-	if ENV['REPOS']
-		repo_slugs.concat(ENV['REPOS'].split(','))
-	end
+  items.delete_if { |item| ignored_repos.include?(item['label']) }
 
-	repo_slugs.sort!
+  # Sort by name, then by status
+  items.sort_by! do |item|
+    if item['class'] == 'bad'
+      [1, item['label']]
+    elsif item['class'] == 'good'
+      [2, item['label']]
+    else
+      [3, item['label']]
+    end
+  end
 
-	items = repo_slugs.map do |repo_slug|
-		label = repo_slug
-		label = repo_slug.gsub(repo_slug_replacements[0],repo_slug_replacements[1]) if repo_slug_replacements
-		item = {
-			'label' => label,
-			'class' => 'none',
-			'url' => '',
-			'items' => [],
-		}
-
-		# Travis info
-		repo_branches = travis_backend.get_branches_by_repo(repo_slug)
-
-		if repo_branches and repo_branches['branches'].length > 0
-			# Latest builds are listed under "branches", but their corresponding branch name
-			# is stored through the "commits" association
-			items = repo_branches['branches']
-				.select do |branch|
-					commit = repo_branches['commits'].find{|commit|commit['id'] == branch['commit_id']}
-					branch_name = commit['branch']
-
-					# Ignore branches not in whitelist
-					if not branch_whitelist.match(branch_name)
-						false
-					# Ignore branches specifically blacklisted
-					elsif branch_blacklist_by_repo.has_key?(repo_slug) and branch_blacklist_by_repo[repo_slug].include?(branch_name)
-						false
-					else
-						true
-					end
-				end
-				.map do |branch|
-					commit = repo_branches['commits'].find{|commit|commit['id'] == branch['commit_id']}
-					branch_name = commit['branch']
-					{
-						'class'=>(["passed","started","created"].include?(branch['state'])) ? 'good' : 'bad', # POSIX return code
-						'label'=>branch_name,
-						'title'=>branch['finished_at'],
-						'result'=>branch['state'],
-						'url'=> 'https://travis-ci.org/%s/builds/%d' % [repo_slug,branch['id']]
-					}
-				end
-
-			item['class'] = (items.find{|b|b["class"] == 'bad'}) ? 'bad' : 'good'
-			item['url'] = items.count ? 'https://travis-ci.org/%s' % repo_slug : ''
-			# Only show items if some are failing
-			item['items'] = (items.find{|b|b["class"] == 'bad'}) ? items : []
-		end
-
-		item
-	end
-
-	# Sort by name, then by status
-	items.sort_by! do|item|
-		if item['class'] == 'bad'
-			[1,item['label']]
-		elsif item['class'] == 'good'
-			[2,item['label']]
-		else
-			[3,item['label']]
-		end
-	end
-
-	if items != $lastTravisItems
-		send_event('travis', {
-			unordered: true,
-			items: items
-		})
-	end
-
-	$lastTravisItems = items
-
+  send_event('travis', unordered: true, items: items)
 end

--- a/jobs/travis.rb
+++ b/jobs/travis.rb
@@ -2,9 +2,7 @@ require 'dashing'
 require File.expand_path('../../lib/travis_backend', __FILE__)
 
 def class_from(build_status)
-  return 'bad' if build_status.nil? || build_status == 1
-
-  'good'
+  (build_status.nil? || build_status == 1) ? 'bad' : 'good'
 end
 
 SCHEDULER.every '2m', first_in: '1s' do |_job|

--- a/lib/github_backend.rb
+++ b/lib/github_backend.rb
@@ -19,10 +19,7 @@ class GithubBackend
   def testable_repos
     projects = JSON.parse(Faraday.get('https://team-api.18f.gov/public/api/projects/').body)
 
-    projects.keys.inject([]) do |result, key|
-      result << projects[key]['github'].first if projects[key]['testable'] == true
-      result
-    end
+    projects.values.select { |p| p['testable'] }.map { |p| p['github'].first }
   end
 
   # Returns EventCollection

--- a/lib/github_backend.rb
+++ b/lib/github_backend.rb
@@ -16,6 +16,15 @@ class GithubBackend
     @logger.level = Logger::DEBUG unless ENV['RACK_ENV'] == 'production'
   end
 
+  def testable_repos
+    projects = JSON.parse(Faraday.get('https://team-api.18f.gov/public/api/projects/').body)
+
+    projects.keys.inject([]) do |result, key|
+      result << projects[key]['github'].first if projects[key]['testable'] == true
+      result
+    end
+  end
+
   # Returns EventCollection
   def contributor_stats_by_author(opts)
     opts = OpenStruct.new(opts) unless opts.is_a? OpenStruct

--- a/lib/travis_backend.rb
+++ b/lib/travis_backend.rb
@@ -13,25 +13,15 @@ class TravisBackend
     @api_base = 'https://api.travis-ci.org/'
   end
 
-  # Returns all repositories for a given organization
-  def get_repos_by_org(org)
-    fetch("repos?owner_name=#{org}")
+  # Returns all repositories that have Travis builds for a given organization
+  def get_enabled_repos_by_org(org)
+    fetch("repos?owner_name=#{org}").select { |repo| !repo['last_build_id'].nil? }
   end
 
   # repo (string) Fully qualified name, incl. owner
   # Returns a single repository as a Hash
   def get_repo(repo)
     fetch("repos/#{repo}")
-  end
-
-  # repo (string) Fully qualified name, incl. owner
-  # Returns a single repository as a Hash
-  def get_builds_by_repo(repo)
-    fetch("repos/#{repo}/builds")
-  end
-
-  def get_branches_by_repo(repo)
-    fetch("repos/#{repo}/branches")
   end
 
   # Returns a Hash

--- a/lib/travis_backend.rb
+++ b/lib/travis_backend.rb
@@ -15,7 +15,7 @@ class TravisBackend
 
   # Returns all repositories that have Travis builds for a given organization
   def get_enabled_repos_by_org(org)
-    fetch("repos?owner_name=#{org}").select { |repo| !repo['last_build_id'].nil? }
+    fetch("repos?owner_name=#{org}").reject { |repo| repo['last_build_id'].nil? }
   end
 
   # repo (string) Fully qualified name, incl. owner

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,4 @@ applications:
     ORGS: 18F
     SINCE: 6.months.ago.beginning_of_month
     GITHUB_LOGIN: monfresh
+    TRAVIS_IGNORED_REPOS: 18F/save-ferris


### PR DESCRIPTION
Why:

We're only interested in the status of repos that actually have builds running on Travis.

How:
I refactored and simplified the Travis job to only use the repo's `last_build_status` as opposed to looking up branches. I'm not sure why the original code was digging into branches, but what I did does the job.

Basically, I'm getting an array of all of 18F's repos that are listed on Travis, except the ones that don't have a `last_build_id`. That means that no builds are running on Travis for that repo, and we can ignore it.

In some cases, some repos were running on the public Travis, but have sinced moved to the private Travis. Since those builds are old and not relevant anymore, we want to exclude them as well, but this is a manual process via the `TRAVIS_IGNORED_REPOS` env var.

In addition, I added a new widget that lists all testable repos that should have builds running on Travis, but do not. Testable repos are obtained via the `team-api`.
