### PR TITLE
Ignore more Travis repos

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,5 +3,5 @@ REPOS=
 SINCE=12.months.ago.beginning_of_month
 GITHUB_LOGIN=
 GITHUB_OAUTH_TOKEN=
-TRAVIS_IGNORED_REPOS=18F/save-ferris
+TRAVIS_IGNORED_REPOS=18F/save-ferris,18F/C2,18F/afsmallbiz,18F/bronto-api,18F/cf-quotas-db,18F/peacecorps-site
 SENTRY_DSN=

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,4 +5,4 @@ applications:
     ORGS: 18F
     SINCE: 6.months.ago.beginning_of_month
     GITHUB_LOGIN: monfresh
-    TRAVIS_IGNORED_REPOS: 18F/save-ferris
+    TRAVIS_IGNORED_REPOS: 18F/save-ferris,18F/C2,18F/afsmallbiz,18F/bronto-api,18F/cf-quotas-db,18F/peacecorps-site


### PR DESCRIPTION
Why:

The repos I added are no longer running on Travis either because they are running on another service, such as Circle CI, or because they are no longer active.
