### PR TITLE
Update testable without CI widget

### DIFF
--- a/jobs/testable_without_ci.rb
+++ b/jobs/testable_without_ci.rb
@@ -9,9 +9,7 @@ require File.expand_path('../../lib/travis_backend', __FILE__)
 # server, but don't.
 SCHEDULER.every '1d', first_in: '1s' do |_job|
   travis_backend = TravisBackend.new
-  github_backend = GithubBackend.new
-
-  testable_repos = github_backend.testable_repos
+  testable_repos = TeamApi.testable_repos
 
   travis_repos = testable_repos.map { |repo| travis_backend.get_repo(repo) }
   repos_without_builds = travis_repos.select { |repo| repo['last_build_id'].nil? }

--- a/lib/github_backend.rb
+++ b/lib/github_backend.rb
@@ -16,12 +16,6 @@ class GithubBackend
     @logger.level = Logger::DEBUG unless ENV['RACK_ENV'] == 'production'
   end
 
-  def testable_repos
-    projects = JSON.parse(Faraday.get('https://team-api.18f.gov/public/api/projects/').body)
-
-    projects.values.select { |p| p['testable'] }.map { |p| p['github'].first }
-  end
-
   # Returns EventCollection
   def contributor_stats_by_author(opts)
     opts = OpenStruct.new(opts) unless opts.is_a? OpenStruct

--- a/lib/team_api.rb
+++ b/lib/team_api.rb
@@ -1,0 +1,8 @@
+class TeamApi
+  def self.testable_repos
+    projects = JSON.parse(Faraday.get('https://team-api.18f.gov/public/api/projects/').body)
+
+    projects['results'].select { |p| p['testable'] && p['status'] != 'deprecated' }.
+      map { |p| p['github'].first }
+  end
+end


### PR DESCRIPTION
Why:
The team-api JSON response has changed to include the array of projects inside a `results` key.

This refactors the widget to properly parse the JSON response, and moves the `testable_repos` to a TeamApi class since it's not related to the GithubBackend class.
