### PR TITLE
Remove unused code and clean up GithubBackend

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,4 +4,3 @@ SINCE=12.months.ago.beginning_of_month
 GITHUB_LOGIN=
 GITHUB_OAUTH_TOKEN=
 TRAVIS_IGNORED_REPOS=18F/save-ferris,18F/C2,18F/afsmallbiz,18F/bronto-api,18F/cf-quotas-db,18F/peacecorps-site
-SENTRY_DSN=

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'i18n'
 gem 'faraday', '~> 0.9'
 gem 'faraday-http-cache'
 gem 'activesupport'
-gem 'sentry-raven'
 gem 'typhoeus'
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.3.8)
     backports (3.6.6)
-    certifi (14.5.14)
     coffee-script (2.2.0)
       coffee-script-source
       execjs
@@ -70,9 +69,6 @@ GEM
     sawyer (0.6.0)
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
-    sentry-raven (0.14.0)
-      certifi
-      faraday (>= 0.7.6)
     sinatra (1.4.6)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -116,5 +112,4 @@ DEPENDENCIES
   rake
   rspec
   rspec-mocks
-  sentry-raven
   typhoeus

--- a/README.md
+++ b/README.md
@@ -124,13 +124,6 @@ Now you're ready to add your app to Heroku:
 	heroku plugins:install git://github.com/ddollar/heroku-config.git
 	heroku config:push
 
-## Logging through Sentry
-
-The project has optional [Sentry](http://getsentry.com) integration for logging exceptions.
-Its particularly useful to capture Github API errors, e.g. when a project has been renamed.
-To use it, configure your `SENTRY_DSN` in `.env` ([docs](https://getsentry.com/docs/)).
-You'll need to sign up to Sentry to receive a valid DSN.
-
 # Contributing
 
 Pull requests are very welcome! Please make sure that the code you're fixing is actually

--- a/jobs/issues_status.rb
+++ b/jobs/issues_status.rb
@@ -10,8 +10,8 @@ SCHEDULER.every '1h', first_in: '1s' do |_job|
   opened_series = [[], []]
   closed_series = [[], []]
   issues_by_period = backend.issue_count_by_status(
-    orgs: (ENV['ORGS'].split(',') if ENV['ORGS']),
-    repos: (ENV['REPOS'].split(',') if ENV['REPOS']),
+    orgs: (ENV['ORGS'].split(',')),
+    repos: (ENV.fetch('REPOS', '').split(',')),
     since: ENV['SINCE']
   ).group_by_month(ENV['SINCE'].to_datetime)
   issues_by_period.each_with_index do |(period, issues), i|

--- a/jobs/meta_stats.rb
+++ b/jobs/meta_stats.rb
@@ -6,8 +6,8 @@ require File.expand_path('../../lib/helper', __FILE__)
 SCHEDULER.every '1h', first_in: '1s' do |_job|
   backend = GithubBackend.new
   repos = backend.get_repos(
-    orgs: (ENV['ORGS'].split(',') if ENV['ORGS']),
-    repos: (ENV['REPOS'].split(',') if ENV['REPOS']),
+    orgs: (ENV['ORGS'].split(',')),
+    repos: (ENV.fetch('REPOS', '').split(',')),
     since: ENV['SINCE']
   )
 

--- a/jobs/pull_requests.rb
+++ b/jobs/pull_requests.rb
@@ -9,8 +9,8 @@ SCHEDULER.every '1h', first_in: '1s' do |_job|
 
   pulls_by_period = backend.pull_count_by_status(
     period: 'month',
-    orgs: (ENV['ORGS'].split(',') if ENV['ORGS']),
-    repos: (ENV['REPOS'].split(',') if ENV['REPOS']),
+    orgs: (ENV['ORGS'].split(',')),
+    repos: (ENV.fetch('REPOS', '').split(',')),
     since: ENV['SINCE']
   ).group_by_month(ENV['SINCE'].to_datetime)
 

--- a/jobs/travis.rb
+++ b/jobs/travis.rb
@@ -10,10 +10,8 @@ SCHEDULER.every '2m', first_in: '1s' do |_job|
   enabled_repos = []
   ignored_repos = ENV['TRAVIS_IGNORED_REPOS'].split(',').compact
 
-  if ENV['ORGS']
-    ENV['ORGS'].split(',').each do |org|
-      enabled_repos = travis_backend.get_enabled_repos_by_org(org)
-    end
+  ENV['ORGS'].split(',').each do |org|
+    enabled_repos = travis_backend.get_enabled_repos_by_org(org)
   end
 
   items = enabled_repos.map do |repo|

--- a/lib/github_backend.rb
+++ b/lib/github_backend.rb
@@ -4,7 +4,6 @@ require 'ostruct'
 require 'json'
 require 'active_support'
 require 'active_support/core_ext'
-require 'raven'
 require_relative 'event'
 require_relative 'event_collection'
 
@@ -23,134 +22,12 @@ class GithubBackend
   end
 
   # Returns EventCollection
-  def contributor_stats_by_author(opts)
-    opts = OpenStruct.new(opts) unless opts.is_a? OpenStruct
-    events = GithubDashing::EventCollection.new
-    get_repos(opts).each do |repo|
-      # Can't limit timeframe
-      begin
-        stats = request('contributors_stats', [repo]) || []
-        next unless stats.is_a?(Array)
-        stats.each do |stat|
-          stat.weeks.each do |week|
-            next unless stat.author
-            events << GithubDashing::Event.new(type: 'commits_additions',
-                                               key: stat.author.login.dup,
-                                               datetime: Time.at(week.w).to_datetime,
-                                               value: week.a) if week.a > 0
-            events << GithubDashing::Event.new(type: 'commits_deletions',
-                                               key: stat.author.login.dup,
-                                               datetime: Time.at(week.w).to_datetime,
-                                               value: week.d) if week.d > 0
-            events << GithubDashing::Event.new(type: 'commits',
-                                               key: stat.author.login.dup,
-                                               datetime: Time.at(week.w).to_datetime,
-                                               value: week.c) if week.c > 0
-          end
-        end
-      rescue Octokit::Error => exception
-        Raven.capture_exception(exception)
-      end
-    end
-
-    events
-  end
-
-  # Returns EventCollection
-  def issue_comment_count_by_author(opts)
-    opts = OpenStruct.new(opts) unless opts.is_a? OpenStruct
-    events = GithubDashing::EventCollection.new
-    get_repos(opts).each do |repo|
-      begin
-        request('issues_comments', [repo, { since: opts.since }]).each do |issue|
-          next unless issue.user
-          events << GithubDashing::Event.new(type: 'issues_comments',
-                                             key: issue.user.login.dup,
-                                             datetime: issue.created_at.to_datetime)
-        end
-      rescue Octokit::Error => exception
-        Raven.capture_exception(exception)
-      end
-    end
-
-    events
-  end
-
-  # Returns EventCollection
-  def pull_count_by_author(opts)
-    opts = OpenStruct.new(opts) unless opts.is_a? OpenStruct
-    events = GithubDashing::EventCollection.new
-    get_repos(opts).each do |repo|
-      begin
-        request('pulls', [repo, { state: 'all', since: opts.since }]).each do |pull|
-          state_desc = (pull.state == 'open') ? 'opened' : 'closed'
-          next unless pull.user
-          events << GithubDashing::Event.new(type: "pulls_#{state_desc}",
-                                             key: pull.user.login.dup,
-                                             datetime: pull.created_at.to_datetime)
-        end
-      rescue Octokit::Error => exception
-        Raven.capture_exception(exception)
-      end
-    end
-
-    events
-  end
-
-  # Returns EventCollection
-  def pull_comment_count_by_author(opts)
-    opts = OpenStruct.new(opts) unless opts.is_a? OpenStruct
-    events = GithubDashing::EventCollection.new
-    get_repos(opts).each do |repo|
-      begin
-        request('pulls_comments', [repo, { since: opts.since }]).each do |comment|
-          next unless comment.user
-          events << GithubDashing::Event.new(type: 'pulls_comments',
-                                             key: comment.user.login.dup,
-                                             datetime: comment.created_at.to_datetime)
-        end
-      rescue Octokit::Error => exception
-        Raven.capture_exception(exception)
-      end
-    end
-
-    events
-  end
-
-  # Returns EventCollection
-  def issue_count_by_author(opts)
-    opts = OpenStruct.new(opts) unless opts.is_a? OpenStruct
-    events = GithubDashing::EventCollection.new
-    get_repos(opts).each do |repo|
-      begin
-        issues = request('issues', [repo, { since: opts.since, state: 'all' }])
-        issues.each do |issue|
-          next unless issue.user
-
-          # TODO: Attribute to closer, not to issue author
-          # state_desc = (issue.state == 'open') ? 'opened' : 'closed'
-
-          events << GithubDashing::Event.new(
-            # type: "issues_#{state_desc}",
-            type: 'issues_opened',
-            key: issue.user.login.dup,
-            datetime: issue.created_at.to_datetime)
-        end
-      rescue Octokit::Error => exception
-        Raven.capture_exception(exception)
-      end
-    end
-
-    events
-  end
-
-  # Returns EventCollection
   def issue_count_by_status(opts)
     opts = OpenStruct.new(opts) unless opts.is_a? OpenStruct
     events = GithubDashing::EventCollection.new
     get_repos(opts).each do |repo|
       begin
-        issues = request('issues', [repo, { since: opts.since, state: 'all' }])
+        issues = Octokit.issues(repo, since: opts.since, state: 'all')
 
         # Filter to issues in the specified timeframe
         issues.select! do|issue|
@@ -172,7 +49,7 @@ class GithubBackend
                                              value: 1)
         end
       rescue Octokit::Error => exception
-        Raven.capture_exception(exception)
+        logger.debug("Octokit exception: #{exception}")
       end
     end
 
@@ -192,7 +69,7 @@ class GithubBackend
     events = GithubDashing::EventCollection.new
     get_repos(opts).each do |repo|
       begin
-        pulls = request('pulls', [repo, { state: 'all', since: opts.since }])
+        pulls = Octokit.pulls(repo, state: 'all', since: opts.since)
         pulls.select! { |pull| pull.created_at.to_datetime > opts.since.to_datetime }
         pulls.each do |pull|
           state_desc = (pull.state == 'open') ? 'opened' : 'closed'
@@ -202,58 +79,27 @@ class GithubBackend
                                              value: 1)
         end
       rescue Octokit::Error => exception
-        Raven.capture_exception(exception)
+        logger.debug("Octokit exception: #{exception}")
       end
     end
 
     events
   end
 
-  def user(name)
-    request('user', [name])
-  end
-
-  def repo_stats(_opts)
-    # TODO
-  end
-
-  def organization_member?(org, user)
-    request('organization_member?', [org, user])
-  end
-
   def get_repos(opts)
     opts = OpenStruct.new(opts) unless opts.is_a? OpenStruct
     repos = []
-    repos = repos.concat(opts.repos) unless opts.repos.nil?
-    unless opts.orgs.nil?
-      opts.orgs.each do |org|
-        begin
-          repos = repos.concat(request('org_repos', [org, { type: 'owner' }]).
-                  map { |repo| repo.full_name.dup })
-        rescue Octokit::Error => exception
-          Raven.capture_exception(exception)
-        end
+    repos = repos.concat(opts.repos)
+
+    opts.orgs.each do |org|
+      begin
+        repos = repos.concat(Octokit.org_repos(org, type: 'owner').
+                map { |repo| repo.full_name.dup })
+      rescue Octokit::Error => exception
+        logger.debug("Octokit exception: #{exception}")
       end
     end
 
     repos
-  end
-
-  # Use a new client for each request, to avoid excessive memory leaks
-  # caused by Sawyer middleware (3MB JSON turns into >150MB memory usage)
-  def request(method, args)
-    client = Octokit::Client.new(
-      login: ENV['GITHUB_LOGIN'],
-      access_token: ENV['GITHUB_OAUTH_TOKEN']
-    )
-    result = client.send(method, *args) do|request|
-      request.options.timeout = 60
-      request.options.open_timeout = 60
-    end
-    client = nil # rubocop:disable Lint/UselessAssignment
-    GC.start
-    Octokit.reset!
-
-    result
   end
 end


### PR DESCRIPTION
- Remove unused code related to Sentry
- Remove unused Github Backend methods
- Raise an error if `ORGS` env var is not set since it is required for most widgets to work
- Use `fetch` with a default value to avoid having to check if the `REPOS` env var is nil each time
